### PR TITLE
[DNM] Changes for an emulation in gossipsub-testground

### DIFF
--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -144,7 +144,7 @@ mod backoff;
 mod behaviour;
 mod config;
 mod gossip_promises;
-mod handler;
+pub mod handler;
 mod mcache;
 pub mod metrics;
 mod peer_score;
@@ -152,9 +152,9 @@ pub mod subscription_filter;
 pub mod time_cache;
 mod topic;
 mod transform;
-mod types;
+pub mod types;
 
-mod rpc_proto;
+pub mod rpc_proto;
 
 pub use self::behaviour::{Gossipsub, GossipsubEvent, MessageAuthenticity};
 pub use self::transform::{DataTransform, IdentityTransform};


### PR DESCRIPTION
[DNM]
This PR is opened to show diffs in the `gossipsub-testground` branch or describe why the branch is created.

Implementing an emulation for gossipsub is in progress in https://github.com/sigp/gossipsub-testground . In order to emulate malicious behavior, we are using the gossipsub implementation in the `gossipsub-testground` branch.